### PR TITLE
Allowing fake document numbers to be generated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # DigitCheckSum
 
 Hi there, I'm glad you're looking in this gem!
-The aim of this gem is to allow **any kind** of document to be validated through calculation of [**Check Digit/Digit Checksum**](https://en.wikipedia.org/wiki/Check_digit).
+The aim of this gem is to allow **any kind** of document to be validated e generated through calculation of [**Check Digit/Digit Checksum**](https://en.wikipedia.org/wiki/Check_digit).
 
-What this mean? This mean that you can validated any kind of documents such: **Passport numbers**, **Federal ID number**, **Books ISBN**, or even **create your own document** number, check `examples/` for more details.
+What this mean? This mean that you can **validate** and **generate fake numbers** of any kind of documents such: **Passport numbers**, **Federal ID number**, **Books ISBN**, or even **create your own document** number, check `examples/` for more details.
 
 **Tip**: Check [`examples/h4ck.rb`](examples/h4ck.rb) to see `h4ck` document specification, this is a sample document who can be manipulated using this library!
 
@@ -29,7 +29,10 @@ Or install it yourself as:
 
 ## Usage
 
-This gem by yourself don't do anything unless you create a class that inherit from `DigitChecksum::BaseDocument` class, example:
+This gem by yourself don't do anything unless you create a class that inherit from `DigitChecksum::BaseDocument` class, but when properly inherited and configured, believe me, you gain **awesomeness**!
+
+Don't you believe me? See for yourself an example:
+
 
 ```ruby
 require 'digit_checksum'
@@ -49,11 +52,25 @@ class CNPJ < DigitChecksum::BaseDocument
   # match format such as: 99.999.999/9999-99 | 99-999-999/9999-99 | 99999999/999999 | 99999999999999
   valid_format_regexp %r{(\d{2})[-.]?(\d{3})[-.]?(\d{3})[\/]?(\d{4})[-.]?(\d{2})}
 
+  # mask utilized to prettify doc number
   pretty_format_mask %(%s.%s.%s/%s-%s)
+
+  # numbers sampled to generate new document numbers
+  generator_numbers (0..9).to_a
 end
 ```
 
 The example below it's intent to validated brazilian `CNPJ` documents, equivalent to `Corporate Taxpayer Registry Number`, so this can be used to:
+
+#### Generate fake document numbers
+
+```
+CNPJ.generate # "79.552.921/0786-55"
+
+CNPJ.generate(false)  # 85215313606778 -- without pretty formating
+
+```
+
 
 #### Calculate check digits
 ```ruby
@@ -82,13 +99,13 @@ CNPJ.valid?(12345678000195) # true
 
 ```ruby
 # belows returns [1, 2, 3, 4, 5, 6, 7, 8, 0, 0, 0, 1, 9, 5]
-CNPJ.normalize_document_number("123.456.78/0001-95") 
+CNPJ.normalize_number("123.456.78/0001-95") 
 
-CNPJ.normalize_document_number_to_s("123.456.78/0001-95") # "12345678000195"
+CNPJ.normalize_number_to_s("123.456.78/0001-95") # "12345678000195"
 
-CNPJ.pretty_formatted("123456780001") # "123.456.78/0001-95"
+CNPJ.pretty_formatted("123456780001") # "123.456.78/0001-95" -- also aliased as CNPJ.pretty(number) or CNPJ.formatted(number)
 
-CNPJ.clear_document_number("123.456.78/0001-95") # "12345678000195"
+CNPJ.clear_number("123.456.78/0001-95") # "12345678000195" -- also aliased as CNPJ.stripped(number)
 ```
 
 See `examples/`for more detailed samples.

--- a/examples/brazilian_cnpj.rb
+++ b/examples/brazilian_cnpj.rb
@@ -12,8 +12,13 @@ class CNPJ < DigitChecksum::BaseDocument
   valid_format_regexp %r{(\d{2})[-.]?(\d{3})[-.]?(\d{3})[\/]?(\d{4})[-.]?(\d{2})}
 
   pretty_format_mask %(%s.%s.%s/%s-%s)
+
+  # numbers sampled to generate new document numbers
+  generator_numbers (0..9).to_a
 end
 
+CNPJ.generate
+CNPJ.valid?(CNPJ.generate)
 
 CNPJ.valid?(nil) # false
 CNPJ.valid?(69739073000104) # true

--- a/examples/brazilian_cpf.rb
+++ b/examples/brazilian_cpf.rb
@@ -12,7 +12,13 @@ class CPF < DigitChecksum::BaseDocument
   valid_format_regexp %r{(\d{3})[-.]?(\d{3})[-.]?(\d{3})[-.]?(\d{2})}
 
   pretty_format_mask %(%s.%s.%s-%s)
+
+  # numbers sampled to generate new document numbers
+  generator_numbers (0..9).to_a
 end
+
+CPF.generate
+CPF.valid?(CPF.generate)
 
 CPF.valid?(nil) # false
 CPF.valid?(31777259185) # true

--- a/examples/h4ck.rb
+++ b/examples/h4ck.rb
@@ -23,9 +23,13 @@ class H4ck < DigitChecksum::BaseDocument
 
   # 0101&&1111(0x01)||[16]<07>!29
   # Ex: 0101&&1111(0x01)||[16]<07>!29-110
-  valid_format_regexp %r{(\d{4})\&\&(\d{4})\(0x(\d{2})\)\|\|\[(\d{2})\]\<(\d{2})\>\!(\d{2})\-(\d{3})}
+  valid_format_regexp %r{(\d{4})(\d{4})\(?[0x]?(\d{2})\)?\|?\|?\[?(\d{2})\]?\<?(\d{2})\>?\!?(\d{2})\-?(\d{3})}
 
-  pretty_format_mask %(%s&&%s(0x%s)||[%s]<%s>!%s-VVV;)
+  # XXXX&&XXXX(0xZZ)||[YY]<MM>!DD-VVV;
+  pretty_format_mask %(%s&&%s(0x%s)||[%s]<%s>!%s-%s;)
+
+  # numbers sampled to generate new document numbers
+  generator_numbers (0..9).to_a
 
   def self.favorite_language(document_number)
     document_number = normalize_document_number(document_number)
@@ -39,6 +43,8 @@ root_doc_number = "0101&&1111(0x01)||[16]<07>!29"
 valid_doc_number = "0101&&1111(0x01)||[16]<07>!29-840"
 invalid_doc_number = "0101&&1111(0x01)||[16]<07>!29-841"
 
+H4ck.generate
+H4ck.valid?(H4ck.generate)
 H4ck.normalize_document_number_to_s(root_doc_number) # "0101111101160729"
 H4ck.calculate_verify_digits(root_doc_number) # [8,4,0]
 H4ck.valid?(root_doc_number) # false

--- a/lib/digit_checksum/base_document.rb
+++ b/lib/digit_checksum/base_document.rb
@@ -7,10 +7,20 @@ module DigitChecksum
       :valid_format_regexp,
       :clear_number_regexp,
       :pretty_format_mask,
+      :generator_numbers
     ]
 
     class << self
-      def valid?(document_number, stop = true)
+      def generate(formatted = true)
+        doc_numbers = root_document_digits_count.times.map { get_generator_numbers.sample }
+        doc_numbers.concat(calculate_verify_digits(doc_numbers))
+
+        normalized_number = normalize_number_to_s(doc_numbers)
+
+        formatted ? pretty_formatted(normalized_number) : normalized_number
+      end
+
+      def valid?(document_number)
         # remove all non digits and return an array to be matched with mask
         normalized_document = normalize_document_number(document_number)
 
@@ -130,6 +140,13 @@ module DigitChecksum
       def valid_length?(document_number)
         normalize_document_number(document_number).size == root_document_digits_count + verify_digits_count
       end
+
+      alias :normalize_number_to_s :normalize_document_number_to_s
+      alias :normalize_number :normalize_document_number
+      alias :clear_number :clear_document_number
+      alias :stripped :clear_document_number
+      alias :formatted :pretty_formatted
+      alias :pretty :pretty_formatted
 
       CONSTANTS_MAP.each do |const_identifier|
         define_method "get_#{const_identifier}" do

--- a/lib/digit_checksum/version.rb
+++ b/lib/digit_checksum/version.rb
@@ -1,3 +1,3 @@
 module DigitChecksum
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/spec/digit_checksum_spec.rb
+++ b/spec/digit_checksum_spec.rb
@@ -216,4 +216,20 @@ describe DigitChecksum do
   it 'consider blank document_number as invalid document' do
     expect(FakeDocument.valid?('')).to eq(false)
   end
+
+  it 'must generate valid document numbers' do
+    10.times do
+      generated_doc = FakeDocument.generate
+
+      expect(FakeDocument.valid?(generated_doc)).to eq(true)
+    end
+  end
+
+  it 'must respond to alias methods' do
+    expect(FakeDocument.respond_to?(:stripped)).to eq(true)
+    expect(FakeDocument.respond_to?(:formatted)).to eq(true)
+    expect(FakeDocument.respond_to?(:pretty)).to eq(true)
+    expect(FakeDocument.respond_to?(:normalize_number_to_s)).to eq(true)
+    expect(FakeDocument.respond_to?(:normalize_number)).to eq(true)
+  end
 end

--- a/spec/documents/fake_document.rb
+++ b/spec/documents/fake_document.rb
@@ -13,4 +13,6 @@ class FakeDocument < DigitChecksum::BaseDocument
 
   # pretty formated as XXX.XXX.XXX-XX
   pretty_format_mask %(%s.%s.%s-%s)
+
+  generator_numbers (0..9).to_a
 end


### PR DESCRIPTION
Added method to generate documents number based on given array of numbers.
Next step is allowing custom numbers for each document section(for custom documents such `h4ck` in examples folder)
