### PR TITLE
Major api changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # DigitCheckSum
 
+[![Build Status](https://travis-ci.org/fidelisrafael/digit_checksum.svg)](https://travis-ci.org/fidelisrafael/digit_checksum)
+
 Hi there, I'm glad you're looking in this gem!
 The aim of this gem is to allow **any kind** of document to be validated e generated through calculation of [**Check Digit/Digit Checksum**](https://en.wikipedia.org/wiki/Check_digit).
 

--- a/examples/brazilian_cnpj.rb
+++ b/examples/brazilian_cnpj.rb
@@ -1,20 +1,20 @@
 class CNPJ < DigitChecksum::BaseDocument
-  digits_verify_mask first:  %w(5 4 3 2 9 8 7 6 5 4 3 2),
-                     second: %w(6 5 4 3 2 9 8 7 6 5 4 3 2)
+  set_verify_digits_weights first:  %w(5 4 3 2 9 8 7 6 5 4 3 2),
+                            second: %w(6 5 4 3 2 9 8 7 6 5 4 3 2)
 
   # MOD 11
-  division_factor_modulo 11
+  set_division_factor_modulo 11
 
   # remove any non digit from document number
-  clear_number_regexp %r{[^(\d+)]}
+  set_clear_number_regexp %r{[^(\d+)]}
 
   # match format such as: 99.999.999/9999-99 | 99-999-999/9999-99 | 99999999/999999 | 99999999999999
-  valid_format_regexp %r{(\d{2})[-.]?(\d{3})[-.]?(\d{3})[\/]?(\d{4})[-.]?(\d{2})}
+  set_valid_format_regexp %r{(\d{2})[-.]?(\d{3})[-.]?(\d{3})[\/]?(\d{4})[-.]?(\d{2})}
 
-  pretty_format_mask %(%s.%s.%s/%s-%s)
+  set_pretty_format_mask %(%s.%s.%s/%s-%s)
 
   # numbers sampled to generate new document numbers
-  generator_numbers (0..9).to_a
+  set_generator_numbers (0..9).to_a
 end
 
 CNPJ.generate

--- a/examples/brazilian_cpf.rb
+++ b/examples/brazilian_cpf.rb
@@ -1,20 +1,20 @@
 class CPF < DigitChecksum::BaseDocument
-  digits_verify_mask first:  %w(10 9 8 7 6 5 4 3 2),
-                     second: %w(11 10 9 8 7 6 5 4 3 2)
+  set_verify_digits_weights first:  %w(10 9 8 7 6 5 4 3 2),
+                            second: %w(11 10 9 8 7 6 5 4 3 2)
 
   # MOD 11
-  division_factor_modulo 11
+  set_division_factor_modulo 11
 
   # remove any non digit from document number
-  clear_number_regexp %r{[^(\d+)]}
+  set_clear_number_regexp %r{[^(\d+)]}
 
   # match format such as: 999.999.999-99 | 999-999-999-99 | 99999999999
-  valid_format_regexp %r{(\d{3})[-.]?(\d{3})[-.]?(\d{3})[-.]?(\d{2})}
+  set_valid_format_regexp %r{(\d{3})[-.]?(\d{3})[-.]?(\d{3})[-.]?(\d{2})}
 
-  pretty_format_mask %(%s.%s.%s-%s)
+  set_pretty_format_mask %(%s.%s.%s-%s)
 
   # numbers sampled to generate new document numbers
-  generator_numbers (0..9).to_a
+  set_generator_numbers (0..9).to_a
 end
 
 CPF.generate

--- a/examples/h4ck.rb
+++ b/examples/h4ck.rb
@@ -12,24 +12,24 @@ class H4ck < DigitChecksum::BaseDocument
 
   PROGRAMMINGS_LANGUAGES.default = 'Unknown'
 
-  division_factor_modulo 11
+  set_division_factor_modulo 11
 
-  digits_verify_mask first:  %w(17 16 15 14 13 12 11 10 9 8 7 6 5 4 3 2),
-                     second: %w(18 17 16 15 14 13 12 11 10 9 8 7 6 5 4 3 2),
-                     last:   %w(19 18 17 16 15 14 13 12 11 10 9 8 7 6 5 4 3 2)
+  set_verify_digits_weights first:  %w(17 16 15 14 13 12 11 10 9 8 7 6 5 4 3 2),
+                            second: %w(18 17 16 15 14 13 12 11 10 9 8 7 6 5 4 3 2),
+                            last:   %w(19 18 17 16 15 14 13 12 11 10 9 8 7 6 5 4 3 2)
 
   # remove any non digit and 0x character from document number
-  clear_number_regexp %r{(0x)|[^\d+]}
+  set_clear_number_regexp %r{(0x)|[^\d+]}
 
   # 0101&&1111(0x01)||[16]<07>!29
   # Ex: 0101&&1111(0x01)||[16]<07>!29-110
-  valid_format_regexp %r{(\d{4})(\d{4})\(?[0x]?(\d{2})\)?\|?\|?\[?(\d{2})\]?\<?(\d{2})\>?\!?(\d{2})\-?(\d{3})}
+  set_valid_format_regexp %r{(\d{4})(\d{4})\(?[0x]?(\d{2})\)?\|?\|?\[?(\d{2})\]?\<?(\d{2})\>?\!?(\d{2})\-?(\d{3})}
 
   # XXXX&&XXXX(0xZZ)||[YY]<MM>!DD-VVV;
-  pretty_format_mask %(%s&&%s(0x%s)||[%s]<%s>!%s-%s;)
+  set_pretty_format_mask %(%s&&%s(0x%s)||[%s]<%s>!%s-%s;)
 
   # numbers sampled to generate new document numbers
-  generator_numbers (0..9).to_a
+  set_generator_numbers (0..9).to_a
 
   def self.favorite_language(document_number)
     document_number = normalize_document_number(document_number)

--- a/lib/digit_checksum/base_document.rb
+++ b/lib/digit_checksum/base_document.rb
@@ -2,22 +2,38 @@ module DigitChecksum
   class BaseDocument
 
     CONSTANTS_MAP = [
-      :digits_verify_mask,
+      :root_documents_digits_count,
+      :verify_digits_positions,
+      :digits_ignore_positions,
       :division_factor_modulo,
-      :valid_format_regexp,
+      :verify_digits_weights,
       :clear_number_regexp,
+      :valid_format_regexp,
       :pretty_format_mask,
-      :generator_numbers
+      :generator_numbers,
+      :document_length
     ]
 
     class << self
       def generate(formatted = true)
-        doc_numbers = root_document_digits_count.times.map { get_generator_numbers.sample }
-        doc_numbers.concat(calculate_verify_digits(doc_numbers))
+        document_number = append_verify_digits(generate_root_numbers)
 
-        normalized_number = normalize_number_to_s(doc_numbers)
+        formatted ? pretty_formatted(document_number) : document_number
+      end
 
-        formatted ? pretty_formatted(normalized_number) : normalized_number
+      def append_verify_digits(document_number)
+        document_number = normalize_number(document_number)
+        verify_digits = calculate_verify_digits(document_number)
+
+        obtain_verify_digits_positions.each_with_index {|position, index|
+          document_number.insert(position + index, verify_digits.shift)
+        }
+
+        normalize_number_to_s(document_number.compact)
+      end
+
+      def generate_root_numbers
+        root_document_digits_count.times.map { get_generator_numbers.sample }
       end
 
       def valid?(document_number)
@@ -28,13 +44,36 @@ module DigitChecksum
         return false if normalized_document.nil? || normalized_document.empty?
 
         # if document dont match the exact size, it's invalid
-        return false unless valid_length?(document_number)
+        return false unless valid_length?(normalized_document)
 
-        # remove last two digits to be verified
-        last_digits = normalized_document.slice!(-verify_digits_count,verify_digits_count).map(&:to_i)
+        # remove verify digits to be verified
+        verify_digits = remove_verify_digits!(normalized_document)
+
+        # calculate the new digits based on root document number
         digits = calculate_verify_digits(normalized_document)
 
-        last_digits == digits
+        verify_digits == digits
+      end
+
+      def remove_verify_digits!(document_number)
+        document_number.to_s.gsub!(get_clear_number_regexp, '')
+
+        obtain_verify_digits_positions.each_with_index.flat_map {|position, index|
+          document_number.slice!((position - index), 1)
+        }.map(&:to_i)
+      end
+
+      def obtain_verify_digits_positions
+        begin
+          get_verify_digits_positions
+        # when value its not set
+        rescue NameError => e
+          default_verify_digits_position
+        end
+      end
+
+      def default_verify_digits_position
+        verify_digits_count.times.map {|i| root_document_digits_count + i  }
       end
 
       def invalid?(document_number)
@@ -44,23 +83,28 @@ module DigitChecksum
       def calculate_verify_digits(document_number)
         return [] unless correct_length_based_on_first_mask?(document_number)
 
+        document_number = normalize_number(document_number)
         division_modulo = get_division_factor_modulo
+        digits_positions = obtain_verify_digits_positions.dup
         digits = []
 
-        get_digits_verify_mask.each do |position, mask|
-          document_number = root_document_number(document_number, mask)
-
-          verify_digit = calculate_verify_digit(document_number, mask, division_modulo)
+        get_verify_digits_weights.each_with_index do |data, index|
+          position, mask = *data
+          current_document = root_document_number(document_number, mask)
+          verify_digit = calculate_verify_digit(current_document, mask, division_modulo)
 
           digits << verify_digit
-          document_number << verify_digit
+          digit_position = digits_positions.shift + index
+
+          # just update ref
+          document_number.insert(digit_position, verify_digit)
         end
 
         digits
       end
 
       def root_document_number(document_number, mask = nil)
-        mask ||= get_digits_verify_mask.values[0]
+        mask ||= get_verify_digits_weights.values[0]
 
         normalize_document_number(document_number, mask.size)
       end
@@ -84,9 +128,11 @@ module DigitChecksum
       end
 
       def pretty_formatted(document_number)
-        return "" if normalize_document_number(document_number).empty?
+        normalized_doc = normalize_number_to_s(document_number)
 
-        numbers = document_number.to_s.scan(get_valid_format_regexp).flatten
+        return "" if normalized_doc.empty?
+
+        numbers = normalized_doc.to_s.scan(get_valid_format_regexp).flatten
 
         # document has a value but it's not valid
         return "" if numbers.empty?
@@ -103,9 +149,14 @@ module DigitChecksum
       def calculate_digits_data(document_number, mask, division_factor)
         sum = calculate_digits_sum(document_number, mask)
         quotient = (sum / division_factor)
-        rest = (sum % division_factor)
+
+        rest = calculate_digits_sum_rest(sum, quotient, division_factor)
 
         { sum: sum, quotient: quotient, rest: rest, verify_digit: digit_verify(rest, division_factor) }
+      end
+
+      def calculate_digits_sum_rest(sum, quotient, division_factor)
+        (sum % division_factor)
       end
 
       def calculate_digits_sum(document_number, mask)
@@ -122,15 +173,19 @@ module DigitChecksum
       end
 
       def first_verify_mask
-        get_digits_verify_mask.values[0]
+        get_verify_digits_weights.values[0]
       end
 
       def verify_digits_count
-        get_digits_verify_mask.size
+        get_verify_digits_weights.size
       end
 
       def root_document_digits_count
-        first_verify_mask.size
+        begin
+          get_root_documents_digits_count
+        rescue NameError => e
+          first_verify_mask.size
+        end
       end
 
       def correct_length_based_on_first_mask?(document_number)
@@ -148,17 +203,13 @@ module DigitChecksum
       alias :formatted :pretty_formatted
       alias :pretty :pretty_formatted
 
-      CONSTANTS_MAP.each do |const_identifier|
-        define_method "get_#{const_identifier}" do
-          const_name = const_identifier.to_s.upcase
-
-          self.const_get(const_identifier.upcase)
+      CONSTANTS_MAP.each do |const_name|
+        define_method "get_#{const_name}" do
+          self.const_get(const_name.to_s.upcase)
         end
 
-        define_method const_identifier do |arg|
-          const_name = const_identifier.to_s.upcase
-
-          self.const_set(const_name, arg)
+        define_method "set_#{const_name}" do |value|
+          self.const_set(const_name.to_s.upcase, value)
         end
       end
     end

--- a/lib/digit_checksum/version.rb
+++ b/lib/digit_checksum/version.rb
@@ -1,3 +1,3 @@
 module DigitChecksum
-  VERSION = "0.1.1"
+  VERSION = "0.2.0"
 end

--- a/spec/digit_checksum_spec.rb
+++ b/spec/digit_checksum_spec.rb
@@ -270,4 +270,8 @@ describe DigitChecksum do
     expect(document_number).to eq(expected)
     expect(MyDocument.valid?(document_number)).to be_truthy
   end
+
+  it 'must generated valid document number for custom check digits positions' do
+    expect(MyDocument.valid?(MyDocument.generate)).to be_truthy
+  end
 end

--- a/spec/documents/fake_document.rb
+++ b/spec/documents/fake_document.rb
@@ -1,18 +1,18 @@
 class FakeDocument < DigitChecksum::BaseDocument
-  digits_verify_mask first: %w(10 9 8 7 6 5 4 3 2),
-                     second: %w(11 10 9 8 7 6 5 4 3 2)
+  set_verify_digits_weights first:  %w(10 9 8 7 6 5 4 3 2),
+                            second: %w(11 10 9 8 7 6 5 4 3 2)
 
   # remove any non digit from document number
-  clear_number_regexp %r{[^(\d+)]}
+  set_clear_number_regexp %r{[^(\d+)]}
 
   # MOD 11
-  division_factor_modulo 11
+  set_division_factor_modulo 11
 
   # match format such as: XXX.XXX.XXX-XX | XXX-XXX-XXX-XX | XXXXXXXXX-XX | XXXXXXXXXXX
-  valid_format_regexp %r{(\d{3})[-.]?(\d{3})[-.]?(\d{3})[-.]?(\d{2})}
+  set_valid_format_regexp %r{(\d{3})[-.]?(\d{3})[-.]?(\d{3})[-.]?(\d{2})}
 
   # pretty formated as XXX.XXX.XXX-XX
-  pretty_format_mask %(%s.%s.%s-%s)
+  set_pretty_format_mask %(%s.%s.%s-%s)
 
-  generator_numbers (0..9).to_a
+  set_generator_numbers (0..9).to_a
 end

--- a/spec/documents/my_document.rb
+++ b/spec/documents/my_document.rb
@@ -1,0 +1,18 @@
+class MyDocument < DigitChecksum::BaseDocument
+  set_division_factor_modulo 11
+
+  set_clear_number_regexp %r{[^(\d+)]}
+
+  set_root_documents_digits_count 10
+
+  set_verify_digits_positions [8, 11]
+
+  set_verify_digits_weights first: %w(1 3 4 5 6 7 8 10),
+                            last:  %w(3 2 10 9 8 7 6 5 4 3 2)
+
+  set_valid_format_regexp %r{(\d{3})[-.]?(\d{3})[-.]?(\d{3})[-.]?(\d{3})}
+
+  set_pretty_format_mask %(%s.%s.%s.%s)
+
+  set_generator_numbers (0..9).to_a
+end


### PR DESCRIPTION
This PR makes a lot of changes in this gem API, including:
- Renaming of the `digits_verify_mask` to `set_verify_digits_weights`
- Added the prefix `set_` to **ALL** class methods
- Added the method `append_verify_digits`
- Added the method `remove_verify_digits!`
- Added the method `set_verify_digits_positions`  to allow calculation of checksum of digits in any position of the document
- Added the method `obtain_verify_digits_positions`
- Rewrite of `generate` method to insert verify digits in the correct position
- Added the method `generate_root_numbers` to allow more extensibility from children classes
- Tests updates
