### PR TITLE
Fixing verify_digit calc to not allow 2 digits number

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ One of the greatest abilitys of this library is allowing to check digit checksum
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'digit_checksum', '~> 0.2.1'
+gem 'digit_checksum', '~> 0.2.2'
 ```
 
 And then execute:

--- a/lib/digit_checksum/base_document.rb
+++ b/lib/digit_checksum/base_document.rb
@@ -166,10 +166,12 @@ module DigitChecksum
       end
 
       def digit_verify(quotient_rest, division_factor)
-        # thats the rule, if quotient_rest < 2, so its became 0
-        return 0 if quotient_rest < 2
+        rest = (division_factor - quotient_rest).to_i
 
-        (division_factor - quotient_rest).to_i
+        # if rest has two digits(checkdigit must be a single digit), force 0
+        return 0 if rest >= 10
+
+        rest
       end
 
       def first_verify_mask

--- a/lib/digit_checksum/version.rb
+++ b/lib/digit_checksum/version.rb
@@ -1,3 +1,3 @@
 module DigitChecksum
-  VERSION = "0.2.1"
+  VERSION = "0.2.2"
 end

--- a/spec/digit_checksum_spec.rb
+++ b/spec/digit_checksum_spec.rb
@@ -165,8 +165,8 @@ describe DigitChecksum do
       set_division_factor_modulo 10
     end
 
-    class FakeDocumentModulo13 < FakeDocument
-      set_division_factor_modulo 13
+    class FakeDocumentModulo7 < FakeDocument
+      set_division_factor_modulo 7
     end
 
     class FakeDocumentModulo3 < FakeDocument
@@ -174,16 +174,16 @@ describe DigitChecksum do
     end
 
     modulo10_verify_digits = FakeDocumentModulo10.calculate_verify_digits(document_number)
-    modulo13_verify_digits = FakeDocumentModulo13.calculate_verify_digits(document_number)
+    modulo13_verify_digits = FakeDocumentModulo7.calculate_verify_digits(document_number)
     modulo3_verify_digits = FakeDocumentModulo3.calculate_verify_digits(document_number)
 
     # in base 10 verify digits will be [0, 5]
-    # in base 13 verify digits will be [11, 3]
-    # in base 3 verify digits will be [0, 0]
+    # in base 13 verify digits will be [7, 4]
+    # in base 3 verify digits will be [3, 3]
 
     expect(modulo10_verify_digits).to eq([0, 5])
-    expect(modulo13_verify_digits).to eq([11, 3])
-    expect(modulo3_verify_digits).to eq([0, 0])
+    expect(modulo13_verify_digits).to eq([7, 4])
+    expect(modulo3_verify_digits).to eq([3, 3])
   end
 
   it 'correctly clear document number based on clear_number_regexp' do


### PR DESCRIPTION
This solve a bug with division_modulo, now any `division_modulo` can be used and the calc will return what is expected.
